### PR TITLE
tables: Pods with multiple volumes are now listed with all volumes

### DIFF
--- a/tables/volumes.go
+++ b/tables/volumes.go
@@ -94,14 +94,14 @@ func (t *VolumesTable) getVolumesFromAllPods() []*VolumeRow {
 	}
 	volumes := make([]*VolumeRow, 0)
 	for _, pod := range pods.Items {
-		currentVolume := &VolumeRow{}
 		if pod.Spec.Volumes != nil {
 			for _, volume := range pod.Spec.Volumes {
-				currentVolume.volume = &volume
-				currentVolume.fromPod = pod.Name
+				volumes = append(volumes, &VolumeRow{
+					volume:  volume.DeepCopy(),
+					fromPod: pod.Name,
+				})
 			}
 		}
-		volumes = append(volumes, currentVolume)
 	}
 	return volumes
 }

--- a/tables/volumes_test.go
+++ b/tables/volumes_test.go
@@ -56,15 +56,15 @@ func TestVolumesTable_Generate(t *testing.T) {
 						},
 					},
 				},
-				//{	// This is not supported as desired: https://github.com/aquasecurity/kube-query/issues/10
-				//	Name: "volume-2",
-				//	VolumeSource: v1.VolumeSource{
-				//		HostPath: &v1.HostPathVolumeSource{
-				//			Path: "/foo2/bar/baz",
-				//			Type: nil,
-				//		},
-				//	},
-				//},
+				{
+					Name: "volume-2",
+					VolumeSource: v1.VolumeSource{
+						HostPath: &v1.HostPathVolumeSource{
+							Path: "/foo2/bar/baz",
+							Type: nil,
+						},
+					},
+				},
 			},
 		},
 		Status: v1.PodStatus{},
@@ -77,9 +77,9 @@ func TestVolumesTable_Generate(t *testing.T) {
 		{
 			"from_pod": "foo-pod-with-two-volumes", "name": "volume-1", "source": `{"path":"/foo1/bar/baz"}`, "type": "hostPath",
 		},
-		//{
-		//	"from_pod": "foo-pod-with-two-volumes", "name": "volume-2", "source": `{"path":"/foo2/bar/baz"}`, "type": "hostPath",
-		//},
+		{
+			"from_pod": "foo-pod-with-two-volumes", "name": "volume-2", "source": `{"path":"/foo2/bar/baz"}`, "type": "hostPath",
+		},
 	}, genTable)
 
 	t.Run("sad path, list pod returns an error", func(t *testing.T) {


### PR DESCRIPTION
Fixes: https://github.com/aquasecurity/kube-query/issues/10

Signed-off-by: Simarpreet Singh <simar@linux.com>