### PR TITLE
Bug Fix: Support for verbose flag

### DIFF
--- a/kube-query.go
+++ b/kube-query.go
@@ -16,8 +16,10 @@ func main() {
 	socketPath := flag.String("socket", "", "absolute path to the osquery socket")
 	
 	// currently we do not care for these flags, but they must be set for the auto loader of osquery
+	// the verbose flag is optionally given.
 	flag.String("timeout", "", "flag for specifying wait time before registering on autoload") 
 	flag.String("interval", "", "flag for specifying wait time before registering on autoload")
+	flag.String("verbose", "", "show more verbose messages (not yet implemented)")
 	
 	flag.Parse()
 	if len(*kubeconfig) == 0 {

--- a/kube-query.go
+++ b/kube-query.go
@@ -19,7 +19,7 @@ func main() {
 	// the verbose flag is optionally given.
 	flag.String("timeout", "", "flag for specifying wait time before registering on autoload") 
 	flag.String("interval", "", "flag for specifying wait time before registering on autoload")
-	flag.String("verbose", "", "show more verbose messages (not yet implemented)")
+	flag.Bool("verbose", false, "show more verbose messages (not yet implemented)")
 	
 	flag.Parse()
 	if len(*kubeconfig) == 0 {


### PR DESCRIPTION
This PR introduces support for passing the --verbose flag when using the auto load mechanism of osquery.
When passing the --verbose flag on osqueryd, the flag is passed to the extension binary as well. until now we didn't parsed this flag, so we crashed.
The verbose mechanism is still not implemented, but this fixes the crash.

Fixes #14 