### PR TITLE
it adds Auth Provider modules

### DIFF
--- a/kube-query.go
+++ b/kube-query.go
@@ -8,6 +8,15 @@ import (
 	 "github.com/aquasecurity/kube-query/tables"
 	 "github.com/aquasecurity/kube-query/utils"
 	osqueryTable "github.com/kolide/osquery-go/plugin/table"
+	//
+	// Uncomment to load all auth plugins
+	// _ "k8s.io/client-go/plugin/pkg/client/auth"
+	//
+	// Or uncomment to load specific auth plugins
+	// _ "k8s.io/client-go/plugin/pkg/client/auth/azure"
+	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	// _ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+	// _ "k8s.io/client-go/plugin/pkg/client/auth/openstack"
 )
 
 func main() {


### PR DESCRIPTION
Hello,
Uncommenting the right provider auth module before building prevents errors like:
Error on creating kube-client: no Auth Provider found for name "gcp"
the error is produced in the k8s.io/client-go but it can be fixed here.